### PR TITLE
Fix test server init

### DIFF
--- a/__tests__/rpc-websocket-client.spec.ts
+++ b/__tests__/rpc-websocket-client.spec.ts
@@ -17,7 +17,7 @@ describe('WebSocket', () => {
 
         app = mod.createNestApplication();
         app.useWebSocketAdapter(new WsAdapter());
-        await app.listen(testConfig.port);
+        await app.init();
     });
 
     it(`RpcWebSocketClient`, async () => {


### PR DESCRIPTION
When running a test, the error happens as follows:

```
Error: listen EADDRINUSE: address already in use :::7000

    at Server.setupListenHandle [as _listen2] (net.js:1298:14)
    at listenInCluster (net.js:1346:12)
    at Server.listen (net.js:1434:7)
    at ExpressAdapter.listen (/Users/otsuka/IdeaProjects/rpc-websocket-client/node_modules/@nestjs/platform-express/adapters/express-adapter.js:44:32)
    at Proxy.listen (/Users/otsuka/IdeaProjects/rpc-websocket-client/node_modules/@nestjs/core/nest-application.js:141:26)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

I fixed this error referring to the Nestjs document: https://docs.nestjs.com/fundamentals/testing
